### PR TITLE
added code to access stylesheets from the webpack/browserify bundled packages…

### DIFF
--- a/print-html-element.js
+++ b/print-html-element.js
@@ -112,6 +112,12 @@ var PrintElement = function() {
             html.push('<link rel="stylesheet" href="' + link.href + '">');
         });
 
+        // Webpack and browserify embed the styles into the <head> of html page. So it is needed to pull those styles as well to apply styling to print report
+        stylesheets = Array.prototype.slice.call(document.getElementsByTagName('style'));
+        stylesheets.forEach(function (link) {
+            html.push(link.outerHTML);
+        });
+
         // Ensure that relative links work
         html.push('<base href="' + _getBaseHref() + '" />');
         html.push('</head><body class="pe-body">');


### PR DESCRIPTION
Currently the package is unable to pull styles with <style> tag from html page. Hence few styles are missing while exporting data to print.

I have added few lines of code to handle this. I have tested in my application. It is all working fine.

Please merge this into master and publish new version. So that i can consume it.