### PR TITLE
add support for IE11

### DIFF
--- a/src/print-html-element.js
+++ b/src/print-html-element.js
@@ -143,7 +143,7 @@ function PrintHtmlElement() {
         html.push('<base href="' + _getBaseHref() + '" />');
         html.push('</head><body class="pe-body">');
         html.push(elementHtml);
-        html.push('<script type="text/javascript">function printPage(){focus();print();' + ((opts.printMode.toLowerCase() == 'popup') ? 'close();' : '') + '}</script>');
+        html.push('<script type="text/javascript">function printPage(){focus();document.execCommand("print", false, null) ? null: print();;' + ((opts.printMode.toLowerCase() == 'popup') ? 'close();' : '') + '}</script>');
         html.push('</body></html>');
 
         return html.join('');


### PR DESCRIPTION
print() function stopped working in IE11, so you need this workaround.